### PR TITLE
Fix bool condition in truncateByWord

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function truncateByWord(element, maximumHeight) {
     // If the new height now exceeds the `maximumHeight` (where it did not
     // in the previous iteration), we know that we are at most one line
     // over the optimal text length.
-    if (element.offsetHeight >= maximumHeight) {
+    if (element.offsetHeight > maximumHeight) {
       return true;
     }
   }


### PR DESCRIPTION
`element.offsetHeight` === `maximumHeight` does not yet cause a line break, so using `>=` on line 36 will truncate too soon.

It's an issue for elements wider than what's used in the example.

See these screenshots:
- [before: using `>=`](https://i.imgur.com/EKmZekg.png)
- [after: using `>`](https://i.imgur.com/DVsdubx.png)