### PR TITLE
Fix for #7 lineClamp not defined in example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -14,7 +14,7 @@
   <div class="line-clamp">
     Lorem ipsum dolor sit amet, <strong>consectetur adipiscing</strong> elit.
   </div>
-  <script src="/bundle.js"></script>
+  <script src="./bundle.js"></script>
   <script>
     const element = document.querySelector('.line-clamp')
     lineClamp(element, 3)


### PR DESCRIPTION
Loading the bundle file with a relative url worked locally.